### PR TITLE
Handle tornado futures in s3 code

### DIFF
--- a/distributed/s3.py
+++ b/distributed/s3.py
@@ -153,9 +153,9 @@ def _read_avro(bucket_name, prefix='', executor=None, lazy=False,
     dfs = [do(avro_bytes)(b) for b in bytes]
 
     if lazy:
-        yield gen.Return(dfs)
+        raise gen.Return(dfs)
     else:
-        yield gen.Return(executor.compute(*dfs))
+        raise gen.Return(executor.compute(*dfs))
 
 
 def buffer_to_csv(b, **kwargs):
@@ -209,6 +209,6 @@ def _read_csv(bucket_name, prefix='', executor=None, lazy=False,
     dfs = [do(buffer_to_csv)(b) for b in bytes]
 
     if lazy:
-        yield gen.Return(dfs)
+        raise gen.Return(dfs)
     else:
-        yield gen.Return(executor.compute(*dfs))
+        raise gen.Return(executor.compute(*dfs))

--- a/distributed/tests/test_s3.py
+++ b/distributed/tests/test_s3.py
@@ -112,7 +112,7 @@ def test_av_read(s, a, b):
     yield e._start()
     data1 = [json.loads(x.decode()) for x in files[
              'test/accounts.1.json'].split(b'\n')[:-1]]
-    dfs = _read_avro('distributed-test', 'test/data/avro', e, lazy=False,
-                     anon=True)
+    dfs = yield _read_avro('distributed-test', 'test/data/avro', e,
+                           lazy=False, anon=True)
     out = yield e._gather(dfs)
     assert out == [data1, data1]


### PR DESCRIPTION
Two notable changes:

1.  Always yield the result of a ``@gen.coroutine``
2.  ``raise gen.Return``, don't ``yield gen.Return``